### PR TITLE
Update UART_RX_tb.vhd

### DIFF
--- a/Fase1_RX/UART_RX_tb.vhd
+++ b/Fase1_RX/UART_RX_tb.vhd
@@ -67,67 +67,87 @@ begin
 	-----------------------------------------------------------------------------
 	p_main : process
 	begin 
-		RX_sig <= '1';
+		RX_sig <= '0';						-- start bit
           wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- 1
           wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- 2
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- 3
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- 4
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- 5
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- 6
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- 7
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0'; 				-- 8
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '1';				-- stop bit
+			 
+		assert ( seg_ut = "11000000")
+			report "RX did not interprete the information correctly."
+			severity error;
+		----------------------
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- start bit
           wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- 1
           wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- 2
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- 3
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- 4
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '1';				-- 5
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- 6
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '1';				-- 7
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- 8
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '1';				-- stop bit
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+		
+		assert ( seg_ut = "10001000")
+			report "RX did not interprete the information correctly."
+			severity error;
+		----------------------
+					wait for CLK_PER*5208*10;	-- Venter med å sende neste byte. 
+									-- Kan prøve å forsinke utenfor CLK_PER med ns.
+					
+		assert ( seg_ut = "10001000")
+			report "RX changed the information."
+			severity error;
+		----------------------
+          RX_sig <= '0';				-- start bit
           wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- 1
           wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- 2
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- 3
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- 4
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '0';				-- 5
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '1';				-- 6
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '1';				-- 7
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '1';				-- 8
 		wait for CLK_PER*5208;
-          RX_sig <= '1';
+          RX_sig <= '1';				-- stop bit
 		wait for CLK_PER*5208;
-
+		
+		assert ( seg_ut = "11111000")
+			report "RX did not interprete the information correctly."
+			severity error;
 		assert false report "Testbench finished" severity failure;
 	end process p_main;
 


### PR DESCRIPTION
En liten oppdatering av testbenk. Den mangler fortsatt byte-ready signalet og kanskje en funksjon for å skyve inngangsverdiene av 9600-klokka.